### PR TITLE
adding requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,11 @@
-# Requirements
-
 asgiref==3.5.0
 cffi==1.15.0
 cryptography==36.0.1
 Django==4.0.2
 django-cors-headers==3.11.0
 djangorestframework==3.13.1
-jwt==1.3.1
 mysqlclient==2.1.0
 pycparser==2.21
+PyJWT==2.3.0
 pytz==2021.3
 sqlparse==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+# Requirements
+
+asgiref==3.5.0
+cffi==1.15.0
+cryptography==36.0.1
+Django==4.0.2
+django-cors-headers==3.11.0
+djangorestframework==3.13.1
+jwt==1.3.1
+mysqlclient==2.1.0
+pycparser==2.21
+pytz==2021.3
+sqlparse==0.4.2


### PR DESCRIPTION
Added requirements.txt, So that folks can easily install the requirements.

The main confusion was to use which jwt package, I guess its https://pypi.org/project/jwt/

Please add it, it becomes easy for others too.