### PR TITLE
Fixed a typo in UserView

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -54,7 +54,7 @@ class UserView(APIView):
             raise AuthenticationFailed('Unauthenticated!')
 
         try:
-            payload = jwt.decode(token, 'secret', algorithm=['HS256'])
+            payload = jwt.decode(token, 'secret', algorithms=['HS256'])
         except jwt.ExpiredSignatureError:
             raise AuthenticationFailed('Unauthenticated!')
 


### PR DESCRIPTION
algorithm -> algorithms in UserView
which raised an error " jwt.exceptions.DecodeError: It is required that you pass in a value for the "algorithms" argument when calling decode()."